### PR TITLE
Add hide_button_when_fullscreen option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,5 @@ Make your Home Assistant browser fullscreen.
 type: "custom:fullscreen-card"
 go_fullscreen: "enter fullscreen"
 exit_fullscreen: "exit fullscreen"
+hide_button_when_fullscreen: true
 ```

--- a/fullscreen-card.js
+++ b/fullscreen-card.js
@@ -22,6 +22,12 @@ class FullscreenCard extends HTMLElement {
       this.tag.style.borderRadius = "var(--ha-card-border-radius, 4px)";
       this.tag.style.cursor = "pointer";
 
+      addEventListener("fullscreenchange", () => {
+        if (!document.fullscreenElement && this.content.style.display) {
+          this.content.style.display = ""
+        }
+      });
+
       const toggleFullscreen = async () => {
         if (window["fullScreen"] || document.fullscreenElement) {
           await document.exitFullscreen();
@@ -31,6 +37,9 @@ class FullscreenCard extends HTMLElement {
           await document.documentElement.requestFullscreen();
           this.tag.innerHTML =
             this.config["exit_fullscreen"] || "Exit fullscreen";
+          if (this.config["hide_button_when_fullscreen"]) {
+            this.content.style.display = "none"
+          }
         }
       };
       this.tag.onclick = toggleFullscreen;


### PR DESCRIPTION
Zero obligation to merge this but I wanted the option to have the button hide itself after entering full screen (it's for a tablet dashboard which I can't use the normal kiosk apps for due to the age of the hardware/os so I have to use chrome) and I figured I may as well open a PR to merge upstream in case anyone else thinks this might be useful.

Ta!